### PR TITLE
feat:musicSrc supports string or function which returns promise of st…

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -13,16 +13,18 @@ const options = {
   //audio lists model
   audioLists: [
     {
-      name: "丑",
-      singer: "草东没有派对",
-      cover: "https://www.lijinke.cn/music/1387583682387727.jpg",
-      musicSrc: "https://www.lijinke.cn/music/201711082.mp3"
+      name: "Despacito",
+      singer: "Luis Fonsi",
+      cover: "http://res.cloudinary.com/alick/image/upload/v1502689731/Despacito_uvolhp.jpg",
+      musicSrc: () => {
+        return Promise.resolve("http://res.cloudinary.com/alick/video/upload/v1502689683/Luis_Fonsi_-_Despacito_ft._Daddy_Yankee_uyvqw9.mp3")
+      }
     },
     {
-      name: "达尔文",
-      singer: "蔡健雅",
-      cover: "https://www.lijinke.cn/music/5V49G-3GFLn-f6mRjHsGaUAh.jpg",
-      musicSrc: "https://www.lijinke.cn/music/20171108.mp3"
+      name: "Bedtime Stories",
+      singer: "Jay Chou",
+      cover: "http://res.cloudinary.com/alick/image/upload/v1502375978/bedtime_stories_bywggz.jpg",
+      musicSrc: "http://res.cloudinary.com/alick/video/upload/v1502375674/Bedtime_Stories.mp3"
     },
     {
       name: "十年青春换绝症",

--- a/src/index.js
+++ b/src/index.js
@@ -853,30 +853,64 @@ export default class ReactJkMusicPlayer extends PureComponent {
 
     const { name, cover, musicSrc, singer } = audioLists[playId];
 
-    this.setState(
-      {
-        name,
-        cover,
-        musicSrc,
-        singer,
-        playId,
-        currentTime: 0,
-        duration: 0,
-        playing: false,
-        loading: true,
-        loadProgress: 0
-      },
-      () => {
-        this.audio.load();
-      }
-    );
+    switch (typeof(musicSrc)) {
+      case 'function':
+        musicSrc().then(val => {
+          this.setState(
+            {
+              name,
+              cover,
+              musicSrc: val,
+              singer,
+              playId,
+              currentTime: 0,
+              duration: 0,
+              playing: false,
+              loading: true,
+              loadProgress: 0
+            },
+            () => {
+              this.audio.load();
+            }
+          );
 
-    this.props.onAudioPlayTrackChange &&
-      this.props.onAudioPlayTrackChange(
-        playId,
-        audioLists,
-        this.getBaseAudioInfo()
-      );
+          this.props.onAudioPlayTrackChange &&
+            this.props.onAudioPlayTrackChange(
+              playId,
+              audioLists,
+              this.getBaseAudioInfo()
+            );
+        });
+        break;
+      default:
+        this.setState(
+          {
+            name,
+            cover,
+            musicSrc,
+            singer,
+            playId,
+            currentTime: 0,
+            duration: 0,
+            playing: false,
+            loading: true,
+            loadProgress: 0
+          },
+          () => {
+            this.audio.load();
+          }
+        );
+
+        this.props.onAudioPlayTrackChange &&
+          this.props.onAudioPlayTrackChange(
+            playId,
+            audioLists,
+            this.getBaseAudioInfo()
+          );
+
+    }
+
+
   };
   clearAudioDuration = () => {
     this.setState({
@@ -1463,10 +1497,23 @@ export default class ReactJkMusicPlayer extends PureComponent {
       const lastPlayStatus = remember
         ? this.getLastPlayStatus()
         : { playId, playMode: defaultPlayMode };
-      this.setState({
-        ...this.getPlayInfo(audioLists, playId),
-        ...lastPlayStatus
-      });
+
+      const info = this.getPlayInfo(audioLists, playId);
+      switch (typeof(info.musicSrc)) {
+        case 'function':
+          info.musicSrc().then(val => {
+            this.setState({
+              ...info, musicSrc: val,
+              ...lastPlayStatus
+            });
+          });
+          break;
+        default:
+          this.setState({
+            ...info,
+            ...lastPlayStatus
+        });
+      }
     }
   }
   componentWillUnmount() {


### PR DESCRIPTION
Amazing and beautiful library.
I extended it such that `musicSrc` accepts either a string or a function of type `() => Promise<String>` . The use case is for when you only want to get the actual music url when it is able to play it (example: when you play songs from private S3 with expiring url)
example
```
audioLists: [
    {name: "foo",
     singer: "bar",
     cover: "...",
     musicSrc: () => {
          // async code to fetch url
          // return Promise("string") 
     }
   }
]