### PR TITLE
Add assets directory to sideEffects

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prepublishOnly": "yarn build"
   },
   "sideEffects": [
+    "assets/*",
     "dist/*",
     "*.less"
   ],


### PR DESCRIPTION
In my code I import `react-jinke-music-player/assets/index.css`, but when I run Webpack in production mode it discards the import.

Adding the assets folder (or the .css file) to `sideEffects` fixes this.