### PR TITLE
Fix various issues related to volume fade-in/fade-out functionality

### DIFF
--- a/src/config/volumeFade.js
+++ b/src/config/volumeFade.js
@@ -1,0 +1,5 @@
+export const VOLUME_FADE = {
+  IN: 'in',
+  OUT: 'out',
+  NONE: 'none',
+}


### PR DESCRIPTION
Fixes #256

### Issues addressed
- No more delay in pause/play button while fading out
- Fade ins always start from 0
- Remove fade-in when starting a track from the beginning (same as Spotify)
- If you have a long fade-in/fade-out duration and repeatedly click pause/play many times, audio no longer stutters and play/pause buttons are always responsive
    - I changed it so that if you pause in the middle of fading in or play in the middle of fading out, it stops the ongoing fade and starts a new fade (opposite direction)
- Volume bar no longer jumps when you adjust volume in the middle of a fade-in/fade-out
- Pressing "Play" while volume is muted no longer plays audio aloud
- If you are in the middle of a fade-in and you change the volume, the fade in interval re-calculates the deltas and continues transitioning to the new volume.