### PR TITLE
Eliminate noise artifact before fade-ins

### DIFF
--- a/src/components/PlayerMobile.js
+++ b/src/components/PlayerMobile.js
@@ -30,7 +30,7 @@ const PlayerMobile = ({
   locale,
   toggleMode,
   renderAudioTitle,
-  actionButtonIcon,
+  shouldShowPlayIcon,
 }) => (
   <div className={cls(prefix, { 'default-bg': !glassBg, 'glass-bg': glassBg })}>
     <PlayModeTip
@@ -88,10 +88,14 @@ const PlayerMobile = ({
       ) : (
         <span
           className="group play-btn"
-          title={playing ? locale.clickToPauseText : locale.clickToPlayText}
+          title={
+            shouldShowPlayIcon
+              ? locale.clickToPlayText
+              : locale.clickToPauseText
+          }
           onClick={onPlay}
         >
-          {actionButtonIcon}
+          {shouldShowPlayIcon ? icon.play : icon.pause}
         </span>
       )}
       <span

--- a/src/index.js
+++ b/src/index.js
@@ -1296,7 +1296,10 @@ export default class ReactJkMusicPlayer extends PureComponent {
             updateIntervalEndVolume,
             isAutoPlayWhenUserClicked: true,
           },
-          this.loadAndPlayAudio,
+          () => {
+            this.audio.volume = startVolume
+            this.loadAndPlayAudio()
+          },
         )
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1245,9 +1245,10 @@ export default class ReactJkMusicPlayer extends PureComponent {
             this.setState({
               currentVolumeFade: VOLUME_FADE.NONE,
               currentVolumeFadeInterval: undefined,
+              playing: false,
               updateIntervalEndVolume: undefined,
             })
-            // It's possible that the volume level in the UI has changed since beginning of fade
+            // Restore volume so slider does not reset to zero
             this.audio.volume = this.getListeningVolume(this.state.soundValue)
           },
         )
@@ -1258,9 +1259,9 @@ export default class ReactJkMusicPlayer extends PureComponent {
         })
       } else {
         this.setState({ currentVolumeFade: VOLUME_FADE.IN })
+        // Start volume may not be 0 if interrupting a fade-out
         const startVolume = isCurrentlyFading ? this.audio.volume : 0
         const endVolume = this.getListeningVolume(this.state.soundValue)
-        // Always fade in from 0 to current volume
         const {
           fadeInterval: fadeInInterval,
           updateIntervalEndVolume,
@@ -1277,6 +1278,7 @@ export default class ReactJkMusicPlayer extends PureComponent {
               currentVolumeFadeInterval: undefined,
               updateIntervalEndVolume: undefined,
             })
+            // It's possible that the volume level in the UI has changed since beginning of fade
             this.audio.volume = this.getListeningVolume(this.state.soundValue)
           },
         )

--- a/src/index.js
+++ b/src/index.js
@@ -452,19 +452,8 @@ export default class ReactJkMusicPlayer extends PureComponent {
       return null
     }
 
-    let actionButtonIcon
-
-    if (playing) {
-      if (this.state.currentVolumeFade === VOLUME_FADE.OUT) {
-        actionButtonIcon = this.iconMap.play
-      } else {
-        actionButtonIcon = this.iconMap.pause
-      }
-    } else if (this.state.currentVolumeFade === VOLUME_FADE.IN) {
-      actionButtonIcon = this.iconMap.pause
-    } else {
-      actionButtonIcon = this.iconMap.play
-    }
+    const shouldShowPlayIcon =
+      !playing || this.state.currentVolumeFade === VOLUME_FADE.OUT
 
     return createPortal(
       <div
@@ -512,7 +501,7 @@ export default class ReactJkMusicPlayer extends PureComponent {
             locale={locale}
             toggleMode={toggleMode}
             renderAudioTitle={this.renderAudioTitle}
-            actionButtonIcon={actionButtonIcon}
+            shouldShowPlayIcon={shouldShowPlayIcon}
           />
         )}
 
@@ -584,12 +573,14 @@ export default class ReactJkMusicPlayer extends PureComponent {
                         className="group play-btn"
                         onClick={this.onTogglePlay}
                         title={
-                          playing
-                            ? locale.clickToPauseText
-                            : locale.clickToPlayText
+                          shouldShowPlayIcon
+                            ? locale.clickToPlayText
+                            : locale.clickToPauseText
                         }
                       >
-                        {actionButtonIcon}
+                        {shouldShowPlayIcon
+                          ? this.iconMap.play
+                          : this.iconMap.pause}
                       </span>
                     )}
                     <span


### PR DESCRIPTION
I discovered a small issue with fade-ins where you hear a short noise artifact before the music fades in. This was because when `this.loadAndPlayAudio()` is called, it's still at the original volume so you hear the track play at that volume for a very short second before starting the fade-in from 0 (or another starting volume).

### Other changes
- Simplified the play/pause icon logic
- Avoid play/pause button re-render by setting `playing` to `false` earlier (when `this.audio.pause()` is called as opposed to in `onAudioPause`).

Sorry for these bugs! 😬 That should fix all of the issues.
