### PR TITLE
Fix playback issue when fadeIn IS-0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1292,7 +1292,9 @@ export default class ReactJkMusicPlayer extends PureComponent {
             isAutoPlayWhenUserClicked: true,
           },
           () => {
-            this.audio.volume = startVolume
+            if (fadeIn) {
+              this.audio.volume = startVolume
+            }
             this.loadAndPlayAudio()
           },
         )


### PR DESCRIPTION
Found another bug: when `fadeIn` is 0, and you click play, it mutes the audio track. I changed it so that when starting playback, it only changes vol to starting vol when there is a fade in.