### PR TITLE
fix: onAudioPlayTrackChange type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -169,7 +169,11 @@ export interface ReactJkMusicPlayerProps {
   onPlayModeChange?: (playMode: ReactJkMusicPlayerPlayMode) => void
   onModeChange?: (mode: ReactJkMusicPlayerMode) => void
   onAudioListsPanelChange?: (panelVisible: boolean) => void
-  onAudioPlayTrackChange?: (fromIndex: number, endIndex: number) => void
+  onAudioPlayTrackChange?: (
+    currentPlayId: string,
+    audioLists: Array<ReactJkMusicPlayerAudioListProps>,
+    audioInfo: ReactJkMusicPlayerAudioInfo,
+  ) => void
   onAudioListsDragEnd?: (
     currentPlayId: string,
     audioLists: Array<ReactJkMusicPlayerAudioListProps>,


### PR DESCRIPTION
onAudioPlayTrackChange typ was not reflecting the reality, which trigger a TS error in IDEs.

![](https://i.imgur.com/wDE7tc5.png)