### PR TITLE
feature: option to disable build-in playlist panel

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -270,6 +270,10 @@ const options = {
   // https://github.com/SortableJS/Sortable#options
   sortableOptions: {},
 
+  // Disable the build in playlist panel
+  // if disabled, duplicated songs are supported
+  audioListsPanelDisabled: false,
+
   // Music is downloaded handle
   onAudioDownload(audioInfo) {
     console.log('audio download', audioInfo)
@@ -609,6 +613,10 @@ class Demo extends React.PureComponent {
     this.setState({ unmount: true })
   }
 
+  onTogglePlaylist = (e) => {
+    this.updateParams({ audioListsPanelDisabled: e.target.checked })
+  }
+
   onPlayModeChange = (e) => {
     this.updateParams({ playMode: e.target.value })
   }
@@ -795,6 +803,10 @@ class Demo extends React.PureComponent {
               onChange={this.onDrag}
             />
             drag
+          </label>
+          <label htmlFor="audioListsPanelDisabled">
+            <input type="checkbox" id="audioListsPanelDisabled" checked={params.audioListsPanelDisabled} onChange={this.onTogglePlaylist} />
+            audioListsPanelDisabled
           </label>
           <label htmlFor="seeked">
             <input

--- a/src/config/propTypes.js
+++ b/src/config/propTypes.js
@@ -120,4 +120,5 @@ export default {
     fadeOut: PropTypes.number,
   }),
   sortableOptions: PropTypes.object,
+  audioListsPanelDisabled: PropTypes.bool,
 }

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,7 @@ export default class ReactJkMusicPlayer extends PureComponent {
     updateIntervalEndVolume: undefined,
     isAudioSeeking: false,
     isResetCoverRotate: false,
+    audioListsPanelDisabled: false,
   }
 
   static defaultProps = {
@@ -197,6 +198,7 @@ export default class ReactJkMusicPlayer extends PureComponent {
     restartCurrentOnPrev: false,
     // https://github.com/SortableJS/Sortable#options
     sortableOptions: {},
+    audioListsPanelDisabled: false
   }
 
   static propTypes = PROP_TYPES
@@ -274,6 +276,7 @@ export default class ReactJkMusicPlayer extends PureComponent {
       autoHiddenCover,
       showDestroy,
       responsive,
+      audioListsPanelDisabled
     } = this.props
 
     const { locale } = this
@@ -304,7 +307,7 @@ export default class ReactJkMusicPlayer extends PureComponent {
       currentLyric,
       audioLyricVisible,
       isPlayDestroyed,
-      isResetCoverRotate,
+      isResetCoverRotate
     } = this.state
 
     const preloadState =
@@ -644,16 +647,18 @@ export default class ReactJkMusicPlayer extends PureComponent {
 
                 {LyricComponent}
 
-                <span
-                  className="group audio-lists-btn"
-                  title={locale.playListsText}
-                  onClick={this.openAudioListsPanel}
-                >
-                  <span className="audio-lists-icon">
-                    {this.iconMap.playLists}
+                {audioListsPanelDisabled ? null : (
+                  <span
+                    className="group audio-lists-btn"
+                    title={locale.playListsText}
+                    onClick={this.openAudioListsPanel}
+                  >
+                    <span className="audio-lists-icon">
+                      {this.iconMap.playLists}
+                    </span>
+                    <span className="audio-lists-num">{audioLists.length}</span>
                   </span>
-                  <span className="audio-lists-num">{audioLists.length}</span>
-                </span>
+                )}
 
                 {toggleMode && (
                   <span
@@ -671,24 +676,26 @@ export default class ReactJkMusicPlayer extends PureComponent {
           </div>
         )}
         {/* 播放列表面板 */}
-        <AudioListsPanel
-          playing={playing}
-          playId={playId}
-          loading={loading}
-          visible={audioListsPanelVisible}
-          audioLists={audioLists}
-          onPlay={this.audioListsPlay}
-          onCancel={this.closeAudioListsPanel}
-          icon={this.iconMap}
-          isMobile={isMobile}
-          panelToggleAnimate={panelToggleAnimate}
-          glassBg={glassBg}
-          cover={cover}
-          remove={remove}
-          onDelete={this.onDeleteAudioLists}
-          removeId={removeId}
-          locale={locale}
-        />
+        {audioListsPanelDisabled ? null : (
+          <AudioListsPanel
+            playing={playing}
+            playId={playId}
+            loading={loading}
+            visible={audioListsPanelVisible}
+            audioLists={audioLists}
+            onPlay={this.audioListsPlay}
+            onCancel={this.closeAudioListsPanel}
+            icon={this.iconMap}
+            isMobile={isMobile}
+            panelToggleAnimate={panelToggleAnimate}
+            glassBg={glassBg}
+            cover={cover}
+            remove={remove}
+            onDelete={this.onDeleteAudioLists}
+            removeId={removeId}
+            locale={locale}
+          />
+        )}
         {/* 播放模式提示框 */}
         {!isMobile && (
           <PlayModel
@@ -961,12 +968,14 @@ export default class ReactJkMusicPlayer extends PureComponent {
   }
 
   openAudioListsPanel = () => {
-    this.setState(({ audioListsPanelVisible }) => ({
-      initAnimate: true,
-      audioListsPanelVisible: !audioListsPanelVisible,
-    }))
-    this.props.onAudioListsPanelChange &&
-      this.props.onAudioListsPanelChange(!this.state.audioListsPanelVisible)
+    if(!this.state.audioListsPanelDisabled) {
+      this.setState(({ audioListsPanelVisible }) => ({
+        initAnimate: true,
+        audioListsPanelVisible: !audioListsPanelVisible,
+      }))
+      this.props.onAudioListsPanelChange &&
+        this.props.onAudioListsPanelChange(!this.state.audioListsPanelVisible)
+    }
   }
 
   closeAudioListsPanel = (e) => {
@@ -975,11 +984,13 @@ export default class ReactJkMusicPlayer extends PureComponent {
   }
 
   _closeAudioListsPanel = () => {
-    const { audioListsPanelVisible } = this.state
-    this.setState({ audioListsPanelVisible: false })
-    if (audioListsPanelVisible) {
-      this.props.onAudioListsPanelChange &&
+    if(!this.state.audioListsPanelDisabled) {
+      const { audioListsPanelVisible } = this.state
+      this.setState({ audioListsPanelVisible: false })
+      if (audioListsPanelVisible) {
+        this.props.onAudioListsPanelChange &&
         this.props.onAudioListsPanelChange(false)
+      }
     }
   }
 


### PR DESCRIPTION
Users are encouraged to use their own playlist managers anyway and we have everything we need to keep up with the player's internal state (current track info, audioList we pass in, etc.)

Adding option to disable build-in playlist panel actually allows us to have same songs multiple times in the same audioList (like a normal music player, you can add to queue song A twice or more), because now it does not throw an error upon the list render, which uses whole song as a key. 